### PR TITLE
Removed possible jquery-prototype conflict when using both libs

### DIFF
--- a/lib/generators/event_calendar/templates/jq_javascript.js
+++ b/lib/generators/event_calendar/templates/jq_javascript.js
@@ -2,7 +2,7 @@
  * Smart event highlighting
  * Handles when events span rows, or don't have a background color
  */
-$(document).ready(function() {
+jQuery(document).ready(function($) {
   var highlight_color = "#2EAC6A";
   
   // highlight events that have a background color


### PR DESCRIPTION
If you're using both jQuery and Prototype, they'll fight over the $-function. Just use jQuery instead of $ outside the jQuery scope to prevent this.

Thanks for the calendar :-)
