### PR TITLE
JQuery Highlight and row calculation

### DIFF
--- a/generators/event_calendar/templates/jq_javascript.js
+++ b/generators/event_calendar/templates/jq_javascript.js
@@ -9,13 +9,13 @@ jQuery(document).ready(function($) {
   $(".ec-event-bg").live("mouseover", function() {
     event_id = $(this).attr("data-event-id");
 		event_class_name = $(this).attr("data-event-class");
-    $("#ec-"+event_class_name+"-"+event_id).css("background-color", highlight_color);
+    $(".ec-"+event_class_name+"-"+event_id).css("background-color", highlight_color);
   });
   $(".ec-event-bg").live("mouseout", function() {
     event_id = $(this).attr("data-event-id");
 		event_class_name = $(this).attr("data-event-class");
     event_color = $(this).attr("data-color");
-    $("#ec-"+event_class_name+"-"+event_id).css("background-color", event_color);
+    $(".ec-"+event_class_name+"-"+event_id).css("background-color", event_color);
   });
   
   // highlight events that don't have a background color

--- a/generators/event_calendar/templates/jq_javascript.js
+++ b/generators/event_calendar/templates/jq_javascript.js
@@ -3,19 +3,20 @@
  * Handles when events span rows, or don't have a background color
  */
 jQuery(document).ready(function($) {
-  var highlight_color = "#2EAC6A";
+  var highlight_color = "#6ABEFF";
+  var bg_color = null;
   
   // highlight events that have a background color
   $(".ec-event-bg").live("mouseover", function() {
     event_id = $(this).attr("data-event-id");
 		event_class_name = $(this).attr("data-event-class");
+		bg_color = $(".ec-"+event_class_name+"-"+event_id).css("background-color");
     $(".ec-"+event_class_name+"-"+event_id).css("background-color", highlight_color);
   });
   $(".ec-event-bg").live("mouseout", function() {
     event_id = $(this).attr("data-event-id");
 		event_class_name = $(this).attr("data-event-class");
-    event_color = $(this).attr("data-color");
-    $(".ec-"+event_class_name+"-"+event_id).css("background-color", event_color);
+    $(".ec-"+event_class_name+"-"+event_id).css("background-color", bg_color);
   });
   
   // highlight events that don't have a background color

--- a/generators/event_calendar/templates/stylesheet.css
+++ b/generators/event_calendar/templates/stylesheet.css
@@ -169,6 +169,10 @@ a.ec-day-link {
   white-space: nowrap;
 }
 
+.ec-event-bg {
+  background-color: #9aa4ad;
+}
+
 .ec-event :hover {
   /* doesn't look as good as js highlighting */
   /* background-color: #2eac6a; */

--- a/lib/event_calendar/calendar_helper.rb
+++ b/lib/event_calendar/calendar_helper.rb
@@ -213,7 +213,7 @@ module EventCalendar
 
                 cal << %(<td class="ec-event-cell" colspan="#{(dates[1]-dates[0]).to_i + 1}" )
                 cal << %(style="padding-top: #{options[:event_margin]}px;">)
-                cal << %(<div id="ec-#{class_name}-#{event.id}" class="ec-event )
+                cal << %(<div id="ec-#{class_name}-#{event.id}" class="ec-event ec-#{class_name}-#{event.id} )
                 if class_name != "event"
                   cal << %(ec-#{class_name} )
                 end

--- a/lib/event_calendar/calendar_helper.rb
+++ b/lib/event_calendar/calendar_helper.rb
@@ -222,7 +222,7 @@ module EventCalendar
                   cal << %(style="color: #{event.color}; )
                 else
                   cal << %(ec-event-bg" )
-                  cal << %(style="background-color: #{event.color}; )
+                  #cal << %(style="background-color: #{event.color}; )
                 end
 
                 cal << %(padding-top: #{options[:event_padding_top]}px; )

--- a/lib/event_calendar/calendar_helper.rb
+++ b/lib/event_calendar/calendar_helper.rb
@@ -341,7 +341,7 @@ module EventCalendar
         # if we reached the end of the week, calculate this row's height
         if index % 7 == 0
           total_event_height = options[:event_height] + options[:event_margin]
-          calc_row_height = (num_event_rows * total_event_height) + options[:day_nums_height] + options[:event_margin]
+          calc_row_height = ((num_event_rows+2) * total_event_height) + options[:day_nums_height] + options[:event_margin]
           row_height = [min_height, calc_row_height].max
           row_heights << row_height
           num_event_rows = 0


### PR DESCRIPTION
I noticed that when there were lots of events during a day, some of them were not displayed correctly. (row calculation correction)

The javascript to highlight an event upon mouse over (using jquery) was getting an element by ID, meaning that the whole line of an event was not highlighted entirely.  (adding the class selector to correct this behaviour)

Finalement replacing the ID selector (#) in jq.javascript by (.) (ID => class).
