### PR TITLE
Non-prefixed border-radius property

### DIFF
--- a/generators/event_calendar/templates/stylesheet.css
+++ b/generators/event_calendar/templates/stylesheet.css
@@ -165,6 +165,7 @@ a.ec-day-link {
   -webkit-border-radius: 3px;
   -khtml-border-radius: 3px;
   -moz-border-radius: 3px;
+  border-radius: 3px;
   overflow: hidden;
   white-space: nowrap;
 }
@@ -234,4 +235,5 @@ a.ec-day-link {
   -webkit-border-radius: 2px;
   -khtml-border-radius: 2px;
   -moz-border-radius: 2px;
+  border-radius: 2px;
 }

--- a/lib/generators/event_calendar/templates/stylesheet.css
+++ b/lib/generators/event_calendar/templates/stylesheet.css
@@ -165,6 +165,7 @@ a.ec-day-link {
   -webkit-border-radius: 3px;
   -khtml-border-radius: 3px;
   -moz-border-radius: 3px;
+  border-radius: 3px;
   overflow: hidden;
   white-space: nowrap;
 }
@@ -234,4 +235,5 @@ a.ec-day-link {
   -webkit-border-radius: 2px;
   -khtml-border-radius: 2px;
   -moz-border-radius: 2px;
+  border-radius: 2px;
 }


### PR DESCRIPTION
Added the non-prefixed border-radius property to get border-radius support in more browsers. These support the non-prefixed version: Opera 10.5, IE9, Safari 5, Chrome, FF4, iOS 4, Android 2.1+ (according to http://css3please.com).
