### PR TITLE
Adding support for asset-pipeline (Rails >= 3.1).  

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,6 +37,16 @@ To generate the necessary static files AND the example below:
 
   rails generate event_calendar
 
+=== Rails >= 3.1
+
+Add this to your Gemfile:
+  
+  gem 'event-calendar', :require => 'event_calendar'
+
+To generate the necessary static files AND the example below:
+
+  rails generate event_calendar --use-asset-pipeline
+
 === Generator Options
 
   script/generate event_calendar --help
@@ -45,6 +55,7 @@ To generate the necessary static files AND the example below:
   --use-jquery: Generate jQuery javascript
   --use-mootools: Generate MooTools javascript
   --use-all-day: Include an 'all_day' field on events, and display appropriately
+  --use-asset-pipeline: Place js/css in app/assets instead of public.  If you're using Rails >= 3.1 you should include this
 
 You can change the default event model name (Event) and controller/view name (Calendar) by passing in two name arguments:
 

--- a/generators/event_calendar/USAGE
+++ b/generators/event_calendar/USAGE
@@ -1,12 +1,16 @@
 Usage:
 
+    Rails < 3.0
     script/generate event_calendar [EVENT_MODEL VIEW_NAME]
+
+    Rails > 3.0
+    rails generate event_calendar
 
   This will create:
       
     # static files
-      public/stylesheets/event_calendar.css
-      public/javascripts/event_calendar.js
+      (app/assets|public)/stylesheets/event_calendar.css
+      (app/assets|public)public/javascripts/event_calendar.js
       
     # Unless --static-only option is given
     # MVC and supporting files (depending on model and view name)

--- a/generators/event_calendar/event_calendar_generator.rb
+++ b/generators/event_calendar/event_calendar_generator.rb
@@ -4,7 +4,8 @@ class EventCalendarGenerator < Rails::Generator::Base
   default_options :static_only => false,
                   :use_jquery =>  false,
                   :use_all_day => false,
-                  :use_mootools => false
+                  :use_mootools => false,
+                  :use_asset_pipeline => false
   
   attr_reader :class_name, :view_name
   
@@ -18,10 +19,11 @@ class EventCalendarGenerator < Rails::Generator::Base
   def manifest
     record do |m|
       # static files
-      m.file "stylesheet.css", "public/stylesheets/event_calendar.css"
+      raise public_folder
+      m.file "stylesheets.css", "#{public_folder}/stylesheets/event_calendar.css"
       
       script = options[:use_jquery] ? 'jq_javascript.js' : (options[:use_mootools] ? 'mt_javascript.js' : 'javascript.js')
-      m.file script, "public/javascripts/event_calendar.js"
+      m.file script, "#{public_folder}/javascripts/event_calendar.js"
       
       # MVC and other supporting files
       unless options[:static_only]
@@ -49,5 +51,12 @@ class EventCalendarGenerator < Rails::Generator::Base
     end
     opt.on("--use-all-day",
       "Include an 'all_day' field on events, and display appropriately.") { |v| options[:use_all_day] = v }
+    opt.on("--use-asset_pipeline",
+      "Place js/css in app/assets instead of public") { |v| options[:use_asset_pipeline] = v}
   end
+
+  def public_folder
+    options[:use_asset_pipeline] ? "app/assets" : "public"
+  end
+
 end

--- a/lib/generators/event_calendar/event_calendar_generator.rb
+++ b/lib/generators/event_calendar/event_calendar_generator.rb
@@ -14,23 +14,24 @@ class EventCalendarGenerator < Rails::Generators::Base
   end
   class_option :use_all_day,  :type => :boolean, :default => false, :desc => "Add an additional 'all_day' attribute"
   class_option :use_color,    :type => :boolean, :default => false, :desc => "Add an additional 'color' attribute"
+  class_option :use_asset_pipeline, :type => :boolean, :default => false, :desc => "Place assets in app/assets instead of public folder"
   
   def do_it
     say "Adding an all_day column", :yellow if options[:use_all_day]
     say "Adding a color column", :yellow if options[:use_color]
-
+    say "Placing js/css in app/assets", :yellow if options[:use_asset_pipeline]
     if options[:use_jquery]
       say "Using jQuery for scripting", :yellow
-      copy_file 'jq_javascript.js', "public/javascripts/event_calendar.js"
+      copy_file 'jq_javascript.js', "#{public_folder}/javascripts/event_calendar.js"
     elsif options[:use_mootools]
       say "Using MooTools for scripting", :yellow
-      copy_file "mt_javascript.js", "public/javascripts/event_calendar.js"
+      copy_file "mt_javascript.js", "#{public_folder}/javascripts/event_calendar.js"
     else
       say "Using Prototype for scripting", :yellow
-      copy_file 'javascript.js', "public/javascripts/event_calendar.js"
+      copy_file 'javascript.js', "#{public_folder}/javascripts/event_calendar.js"
     end
 
-    copy_file "stylesheet.css", "public/stylesheets/event_calendar.css"
+    copy_file "stylesheet.css", "#{public_folder}/stylesheets/event_calendar.css"
 
     unless options.static_only?
       template "model.rb.erb", "app/models/#{model_name}.rb"
@@ -42,6 +43,10 @@ class EventCalendarGenerator < Rails::Generators::Base
       route "match '/#{view_name}(/:year(/:month))' => '#{view_name}#index', :as => :#{named_route_name}, :constraints => {:year => /\\d{4}/, :month => /\\d{1,2}/}"
     end
 
+  end
+
+  def public_folder
+    options[:use_asset_pipeline] ? "app/assets" : "public"
   end
 
   def model_class_name


### PR DESCRIPTION
Add --use-asset-pipeline and assets will be copied to app/assets.  

It would have been easy to just check for File.directory?("app/assets") and copy there if it exists - but I added to the --user-asset-pipeline to keep it backwards compatible.
