### PR TITLE
Removed deprecated .scoped and find(:all) for rails 4

### DIFF
--- a/lib/event_calendar.rb
+++ b/lib/event_calendar.rb
@@ -49,10 +49,9 @@ module EventCalendar
     
     # Get the events overlapping the given start and end dates
     def events_for_date_range(start_d, end_d, find_options = {})
-      self.scoped(find_options).find(
-        :all,
-        :conditions => [ "(? <= #{self.quoted_table_name}.#{self.end_at_field}) AND (#{self.quoted_table_name}.#{self.start_at_field}< ?)", start_d.to_time.utc, end_d.to_time.utc ],
-        :order => "#{self.quoted_table_name}.#{self.start_at_field} ASC"
+      self.where(find_options).where(
+        "(? <= #{self.quoted_table_name}.#{self.end_at_field}) AND (#{self.quoted_table_name}.#{self.start_at_field}< ?)", start_d.to_time.utc, end_d.to_time.utc).order(
+        "#{self.quoted_table_name}.#{self.start_at_field} ASC"
       )
     end
     


### PR DESCRIPTION
Removing .scoped call and find(:all...) in events_for_date_range function.  Event calendar now works well in Rails 4.10
